### PR TITLE
Make kerbdown regex less greedy

### DIFF
--- a/KerbalStuff/kerbdown.py
+++ b/KerbalStuff/kerbdown.py
@@ -4,7 +4,7 @@ from markdown.util import etree
 
 from urllib.parse import parse_qs, urlparse
 
-EMBED_RE = r'\[\[(?P<url>.+)\]\]'
+EMBED_RE = r'\[\[(?P<url>.+?)\]\]'
 
 def embed_youtube(link):
     q = parse_qs(link.query)


### PR DESCRIPTION
If you have 2 or more embedded links to youtube/imgur parser produces incorrect output.

If first embedded object is youtube video, it produces 1 embedded youtube video with almost all between first `[[` and last `]]` in markdowned doc. If first link is imgur image, it produces correct embedded object but drops all before last `]]`.

This commit fixes such behavior.
