### PR TITLE
Don't count downloads for HEAD requests

### DIFF
--- a/KerbalStuff/blueprints/mods.py
+++ b/KerbalStuff/blueprints/mods.py
@@ -387,7 +387,7 @@ def download(mod_id, mod_name, version):
     if not os.path.isfile(os.path.join(_cfg('storage'), version.download_path)):
         abort(404)
     
-    if request.method != 'HEAD':
+    if request.method == 'GET':
         # Events are aggregated hourly
         if not download or ((datetime.now() - download.created).seconds / 60 / 60) >= 1:
             download = DownloadEvent()


### PR DESCRIPTION
Currently download counts include all HTTP requests. This means that a bot checking for file updates (using the last-modified header) will inadvertently count towards the total download count of a mod. I think this PR fixes a large part of the issue by skipping the download event on HEAD requests.
