### PR TITLE
Update default spec_version to "v1.4"

### DIFF
--- a/KerbalStuff/ckan.py
+++ b/KerbalStuff/ckan.py
@@ -12,7 +12,7 @@ def send_to_ckan(mod):
     if not mod.ckan:
         return
     json_blob = {
-        'spec_version': 1,
+        'spec_version': 'v1.4',
         'identifier': re.sub(r'\W+', '', mod.name),
         '$kref': '#/ckan/kerbalstuff/' + str(mod.id),
         'license': mod.license,


### PR DESCRIPTION
Hey KerbalStuff team. Generally when adding KerbalStuff-hosted mods to CKAN we use KerbalStuffBot's ouput as a template to work off of and it would be a time-saver if it gave us "v1.4" rather than 1 as the spec_version. Thanks a bunch!