### PR TITLE
Remove list of recipients from emails sent out.

### DIFF
--- a/KerbalStuff/celery.py
+++ b/KerbalStuff/celery.py
@@ -24,7 +24,7 @@ def send_mail(sender, recipients, subject, message, important=False):
     message['Subject'] = subject
     message['From'] = sender
     for group in chunks(recipients, 100):
-        message['To'] = ";".join(group)
+        message['To'] = sender
         print("Sending email from {} to {} recipients".format(sender, len(group)))
         smtp.sendmail(sender, group, message.as_string())
     smtp.quit()


### PR DESCRIPTION
One-line to change the 'To' address (as listed) to be the same as the sender - common in bulk mail.  The actual recipients are set by the smtp.sendmail line, and don't change - they are just no longer listed in the headers.
